### PR TITLE
Upgrade to Flask 0.12.3 to fix CVE-2018-1000656

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
 
     packages=['guacamole'],
     install_requires=[
-        'Flask==0.10.1',
+        'Flask==0.12.3',
         'Flask-PyMongo==0.4.0',
     ],
 


### PR DESCRIPTION
@amessinger after receiving some security alerts from Github about this CVE on Flask I've decided to upgrade its version.

Maybe after this change you'll also need to bump Guacamole to version 0.1.1.

PS: I'm working on this again because I'm writing a Go client for Guacamole :smile: 